### PR TITLE
Add SPLOIT_DIR environment variable handling

### DIFF
--- a/man/sploitctl.1
+++ b/man/sploitctl.1
@@ -40,6 +40,10 @@ Script to fetch, install, update and search exploit archives from well-known sit
 \fB\-V\fR           \- print version of sploitctl and exit
 .HP
 \fB\-H\fR           \- print help and exit
+.SH ENVIRONMENT
+.TP
+.I SPLOIT_DIR
+Overrides the default exploit base directory.
 .SH EXAMPLES
 .PP
 .HP

--- a/sploitctl.py
+++ b/sploitctl.py
@@ -45,7 +45,7 @@ LICENSE: str = "GPLv3"
 VERSION: str = "3.0.3"  # sploitctl.py version
 PROJECT: str = "sploitctl"
 
-exploit_path: str = "/usr/share/exploits"  # default exploit base directory
+exploit_path: str = os.getenv('SPLOIT_DIR') if os.getenv('SPLOIT_DIR') else "/usr/share/exploits"  # default exploit base directory
 exploit_repo: dict = {}
 
 decompress_archive: bool = False


### PR DESCRIPTION
Simple feature but allows users to export environment variable which will override the default directory in which the exploits are stored without the need to remember about the -d flag for every single command.